### PR TITLE
feat: remove hover color on items

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@
       <section id="merchants-view" class="view">
           <!-- Data will be displayed here -->
         </section>
-        <section id="items-view" class="view hidden">
+        <section id="items-view" class="items-view view hidden">
           <!-- Data will be displayed here -->
         </section>
         <section id="single-merchant-view" class="view hidden">

--- a/style.css
+++ b/style.css
@@ -78,7 +78,6 @@ nav > button:hover,
   color: #ffffff; 
 }
 
-.item:hover,
 .merchant:hover
 {
   background-color: #f6b696; 
@@ -189,7 +188,7 @@ form {
 
 /* ITEMS SECTION*/
 
-#items-view {
+.items-view {
   background-color: #bbe4e9;
   padding: 20px;
   border: 5px solid #ccc;


### PR DESCRIPTION
Small changes including modifying #view-list to be a class instead as well as removing the color change feature for items when they are hovered over. 

Changing #view-list in CSS fixed an issue with items showing up at the bottom of the page.