### PR TITLE
feat: returns a message if new merchant name empty

### DIFF
--- a/main.js
+++ b/main.js
@@ -113,6 +113,12 @@ function discardMerchantEdits(event) {
 function submitMerchant(event) {
   event.preventDefault()
   var merchantName = newMerchantName.value
+  
+  if (!merchantName.trim()) {
+    showStatus('Please enter a name', false);
+    return;
+  }
+  
   postData('merchants', { name: merchantName })
     .then(postedMerchant => {
       merchants.push(postedMerchant.data)


### PR DESCRIPTION
This PR changes the `submitMerchant` function to not allow en empty field to be submitted.